### PR TITLE
Force Int64 calculation of factorial for 32-bit systems

### DIFF
--- a/src/double_funcs.jl
+++ b/src/double_funcs.jl
@@ -1,7 +1,7 @@
 export sincosh
 
 # Precomputed values
-const inv_fact = [DoubleFloat64(1.0 / BigFloat(factorial(k))) for k = 3:17]
+const inv_fact = [DoubleFloat64(1.0 / BigFloat(factorial(Int64(k)))) for k = 3:17]
 const ninv_fact = length(inv_fact)
 
 


### PR DESCRIPTION
This attempts to fix #19. 